### PR TITLE
Make Postgresql only bind to local port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       POSTGRES_DB: elephant
       NO_TS_TUNE: "true"
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql
     healthcheck:


### PR DESCRIPTION
This PR makes the suggestion to not expose the Postgres Database.

Only the API binds to external port then.